### PR TITLE
Fix style issues

### DIFF
--- a/lib/benchmark/experiment.rb
+++ b/lib/benchmark/experiment.rb
@@ -30,7 +30,7 @@ module Benchmark
 
   class Job
     alias old_item item
-    def item(label = "", &blk)
+    def item(label = '', &blk)
       old_item(label, &blk)
       @list.last << Sample.new
       @list.last << []
@@ -63,10 +63,10 @@ module Benchmark
 
     def rank(all_stats, alpha = 0.05)
       ranked = all_stats.map do |stats|
-        stats.select{ |stat| stat.name == :total }.first
+        stats.select { |stat| stat.name == :total }.first
       end.sort_by { |stat| stat.median }
       is_h0_rejected = true
-      if (all_stats.size > 1)
+      if all_stats.size > 1
         z = Benchmark::Experiment::MannWhitneyUTest::calculate_z(ranked.first.sample, ranked[1].sample)
         p_value = Benchmark::Experiment::MannWhitneyUTest::calculate_probability_z(z)
         is_h0_rejected = Benchmark::Experiment::MannWhitneyUTest::is_null_hypothesis_rejected?(p_value, alpha)
@@ -112,7 +112,7 @@ module Benchmark
         lines << line
       end
 
-      print "".ljust(width)
+      print ''.ljust(width)
       MEASURED_TIMES.values.each_with_index do |head, index|
         print "#{tab}#{head}".ljust(spacing[index])
       end
@@ -122,7 +122,7 @@ module Benchmark
 
       best, is_the_best_significative = rank(all_stats)
 
-      puts "The best \"#{best.name}\" is #{is_the_best_significative ? "" : "not "}significantly (95%) better (total time)."
+      puts "The best \"#{best.name}\" is #{is_the_best_significative ? '' : 'not '}significantly (95%) better (total time)."
 
       all_stats
     end

--- a/lib/benchmark/experiment/descriptive_statistics.rb
+++ b/lib/benchmark/experiment/descriptive_statistics.rb
@@ -1,7 +1,7 @@
 module Benchmark
   module Experiment
     class DescriptiveStatistics
-      def initialize(sample, name ='')
+      def initialize(sample, name = '')
         # raise exception if empty sample
         @name = name
         @sample = sample.sort
@@ -49,12 +49,13 @@ module Benchmark
       def calculate_first_quartile_of(data)
         return calculate_median_of(data[0..(data.size / 2)]) if data.size.odd?
 
-        calculate_median_of(data[0..((data.size - 1)/ 2)])
+        calculate_median_of(data[0..((data.size - 1) / 2)])
       end
+
       def calculate_third_quartile_of(data)
         return calculate_median_of(data[(data.size / 2)..-1]) if data.size.odd?
 
-        calculate_median_of(data[(data.size/ 2)..-1])
+        calculate_median_of(data[(data.size / 2)..-1])
       end
 
     end

--- a/lib/benchmark/experiment/mann_whitney_u_test.rb
+++ b/lib/benchmark/experiment/mann_whitney_u_test.rb
@@ -5,7 +5,7 @@ module Benchmark
     module MannWhitneyUTest
       def self.calculate_U(x, y)
         ranked = concatenate_and_label(x, y)
-        
+
         rank!(ranked)
 
         adjust_ties!(ranked)
@@ -37,13 +37,13 @@ module Benchmark
         if !t.first
           sigma_u = Math::sqrt(n_xy * (n + 1.0) / 12.0)
         else
-          sigma_u = Math::sqrt( n_xy / (n * (n + 1)) * ((n**3 - n) / 12.0 - t.last))
+          sigma_u = Math::sqrt(n_xy / (n * (n + 1)) * ((n**3 - n) / 12.0 - t.last))
         end
 
         (u - mu_u) / sigma_u
       end
 
-      def self.calculate_probability_z(z, two_sided=true)
+      def self.calculate_probability_z(z, two_sided = true)
         prob = (1.0 - Distribution::Normal.cdf(z.abs()))
         prob *= 2.0 if two_sided
         prob
@@ -62,7 +62,7 @@ module Benchmark
         found_ties = ties.size > 0
         [
           found_ties,
-          ties.inject(0) { |a, v| a + (v.size**3 - v.size) / 12.0}
+          ties.inject(0) { |a, v| a + (v.size**3 - v.size) / 12.0 }
         ]
       end
 
@@ -85,7 +85,7 @@ module Benchmark
       def self.rank_sum(ranked, label)
         ranked
           .select { |elem| elem[1] == label }
-          .inject(0) {|rank_sum, elem| rank_sum + elem.last }
+          .inject(0) { |rank_sum, elem| rank_sum + elem.last }
       end
 
       def self.adjust_ties!(ranked)
@@ -93,7 +93,7 @@ module Benchmark
 
         ranked
           .group_by { |e| e.first }
-          .reject { |_,v| v.size < 2 }
+          .reject { |_, v| v.size < 2 }
           .each do |score, data|
             ties[score] = data.inject(0) do |sum, elem|
               sum + elem.last

--- a/spec/unit/experiment_spec.rb
+++ b/spec/unit/experiment_spec.rb
@@ -2,7 +2,7 @@ require_relative '../spec_helper'
 
 describe Benchmark::Experiment do
   let(:cases) do
-    n = 5000000
+    n = 5_000_000
     {
       'for:'    => proc { for i in 1..n; a = "1"; end },
       'times:'  => proc { n.times do   ; a = "1"; end },

--- a/spec/unit/mann_whitney_u_test_spec.rb
+++ b/spec/unit/mann_whitney_u_test_spec.rb
@@ -1,17 +1,9 @@
 require_relative '../spec_helper'
 
 describe Benchmark::Experiment::MannWhitneyUTest do
-  let(:x) {
-    [19, 22, 16, 29, 24]
-  }
-
-  let(:y_no_ties) {
-    [20, 11, 17, 12]
-  }
-
-  let(:y_ties) {
-   [19, 20, 11, 17, 12] 
-  }
+  let(:x)         { [19, 22, 16, 29, 24] }
+  let(:y_no_ties) { [20, 11, 17, 12] }
+  let(:y_ties)    { [19, 20, 11, 17, 12] }
 
   it 'calculates U' do
     Benchmark::Experiment::MannWhitneyUTest::calculate_U(x, y_no_ties).must_equal [3.0, 17.0]
@@ -38,4 +30,3 @@ describe Benchmark::Experiment::MannWhitneyUTest do
     refute Benchmark::Experiment::MannWhitneyUTest::is_null_hypothesis_rejected?(0.9, 0.05)
   end
 end
-


### PR DESCRIPTION
Based on PullReview report.
- Space missing to the left of `{`
- Surrounding space missing for operator `/`
- Surrounding space missing in default value assignment
- 1 trailing blank lines detected
- Remove trailing whitespace
- Avoid using {} for multi line blocks
- Don't use parentheses around the condition of an `if`
- Prefer single quoted strings when you don't need string
  interpolation or special symbols
- Space between `{` and `|` missing
- Space inside parentheses detected
- Space missing after comma
- Space missing inside `}`
- Surrounding space missing in default value assignment
- Use empty lines between defs
- Add underscores to large numeric literals to improve
  their readability
